### PR TITLE
Implement Perforce module

### DIFF
--- a/perforce_triggers/perforce.py
+++ b/perforce_triggers/perforce.py
@@ -1,0 +1,27 @@
+from os import environ
+from P4 import P4, P4Exception
+
+from perforce_triggers import config
+from perforce_triggers import exceptions
+
+
+def connect_to_perforce():
+    try:
+        auth_config = config.get_config()["auth"]
+        environ["P4TICKETS"] = auth_config["p4_tickets"]
+        environ["P4IGNORE"] = ".p4ignore"
+
+        p4_conn = P4()
+        p4_conn.user = auth_config["p4_user"]
+        p4_conn.port = auth_config["p4_port"]
+        p4_conn.connect()
+    except KeyError as config_error:
+        raise exceptions.PerforceTriggersError(
+            "perforce login details are not configured correctly!\n"
+            f"error: missing key {config_error}"
+        )
+    except P4Exception as p4_error:
+        raise exceptions.PerforceTriggersError(
+            f"Failed to connect to perforce server '{auth_config['p4_port']}' "
+            f"as user '{auth_config['p4_user']}'!\nerror: {p4_error}"
+        )

--- a/perforce_triggers/perforce.py
+++ b/perforce_triggers/perforce.py
@@ -1,3 +1,5 @@
+import typing
+
 from os import environ
 from P4 import P4, P4Exception
 
@@ -5,7 +7,7 @@ from perforce_triggers import config
 from perforce_triggers import exceptions
 
 
-def connect_to_perforce():
+def connect_to_perforce() -> P4:
     try:
         auth_config = config.get_config()["auth"]
         environ["P4TICKETS"] = auth_config["p4_tickets"]
@@ -15,6 +17,8 @@ def connect_to_perforce():
         p4_conn.user = auth_config["p4_user"]
         p4_conn.port = auth_config["p4_port"]
         p4_conn.connect()
+
+        return p4_conn
     except KeyError as config_error:
         raise exceptions.PerforceTriggersError(
             "perforce login details are not configured correctly!\n"
@@ -25,3 +29,15 @@ def connect_to_perforce():
             f"Failed to connect to perforce server '{auth_config['p4_port']}' "
             f"as user '{auth_config['p4_user']}'!\nerror: {p4_error}"
         )
+
+
+def get_triggers() -> typing.Optional[typing.List[str]]:
+    try:
+        p4_conn = connect_to_perforce()
+        p4_triggers_output = p4_conn.run_triggers("-o")
+        return (
+            p4_triggers_output[0].get("Triggers", [])
+            if p4_triggers_output else []
+        )
+    except Exception as e:
+        raise exceptions.PerforceTriggersError(str(e))

--- a/perforce_triggers/perforce.py
+++ b/perforce_triggers/perforce.py
@@ -7,7 +7,7 @@ from perforce_triggers import config
 from perforce_triggers import exceptions
 
 
-def connect_to_perforce() -> P4:
+def get_perforce_connection() -> P4:
     try:
         auth_config = config.get_config()["auth"]
         environ["P4TICKETS"] = auth_config["p4_tickets"]
@@ -33,7 +33,7 @@ def connect_to_perforce() -> P4:
 
 def get_triggers() -> typing.Optional[typing.List[str]]:
     try:
-        p4_conn = connect_to_perforce()
+        p4_conn = get_perforce_connection()
         p4_triggers_output = p4_conn.run_triggers("-o")
         return (
             p4_triggers_output[0].get("Triggers", [])

--- a/perforce_triggers/triggers.py
+++ b/perforce_triggers/triggers.py
@@ -96,7 +96,7 @@ class CommandTrigger(Trigger):
         ]
 
 
-def get_triggers() -> typing.List[Trigger]:
+def get_triggers_from_config() -> typing.List[Trigger]:
     config_ = config.get_config()
     trigger_config_list = config_.get("triggers", [])
     trigger_list = []

--- a/tests/test_perforce.py
+++ b/tests/test_perforce.py
@@ -4,13 +4,13 @@ from P4 import P4Exception
 from perforce_triggers import perforce, exceptions
 
 
-def test_connect_to_perforce(mocker):
+def test_get_perforce_connection(mocker):
     # Incorrect configuration
     config_ = {}
     mocker.patch("perforce_triggers.config.get_config", return_value=config_)
 
     with pytest.raises(exceptions.PerforceTriggersError) as error_:
-        perforce.connect_to_perforce()
+        perforce.get_perforce_connection()
     assert "perforce login details are not configured correctly!" in str(error_)
 
     # missing p4 tickets path
@@ -24,7 +24,7 @@ def test_connect_to_perforce(mocker):
     mocker.patch("perforce_triggers.config.get_config", return_value=config_)
 
     with pytest.raises(exceptions.PerforceTriggersError) as error_:
-        perforce.connect_to_perforce()
+        perforce.get_perforce_connection()
     assert "perforce login details are not configured correctly!" in str(error_)
 
     # connection error
@@ -43,7 +43,7 @@ def test_connect_to_perforce(mocker):
     mocker.patch("P4.P4", new=P4Mock())
     
     with pytest.raises(exceptions.PerforceTriggersError) as error_:
-        perforce.connect_to_perforce()
+        perforce.get_perforce_connection()
     assert "Failed to connect to perforce server 'perforce:1666' as user 'jdoe'" in str(error_)
 
 
@@ -55,7 +55,7 @@ def test_get_triggers(mocker):
             return triggers_output
     
     # no triggers
-    mocker.patch("perforce_triggers.perforce.connect_to_perforce", return_value=P4Mock())
+    mocker.patch("perforce_triggers.perforce.get_perforce_connection", return_value=P4Mock())
     assert perforce.get_triggers() == []
 
     # trigger list
@@ -63,7 +63,7 @@ def test_get_triggers(mocker):
     assert perforce.get_triggers() == ["some trigger"]
 
     # exception
-    mocker.patch("perforce_triggers.perforce.connect_to_perforce", side_effect=P4Exception("failed to connect"))
+    mocker.patch("perforce_triggers.perforce.get_perforce_connection", side_effect=P4Exception("failed to connect"))
 
     with pytest.raises(exceptions.PerforceTriggersError) as error_:
         perforce.get_triggers()

--- a/tests/test_perforce.py
+++ b/tests/test_perforce.py
@@ -1,0 +1,47 @@
+from P4 import P4Exception
+import pytest
+from perforce_triggers import perforce, exceptions
+import perforce_triggers
+
+
+def test_connect_to_perforce(mocker):
+    # Incorrect configuration
+    config_ = {}
+    mocker.patch("perforce_triggers.config.get_config", return_value=config_)
+
+    with pytest.raises(exceptions.PerforceTriggersError) as error_:
+        perforce.connect_to_perforce()
+    assert "perforce login details are not configured correctly!" in str(error_)
+
+    # missing p4 tickets path
+    config_ = {
+        "auth": {
+            "p4_user": "jdoe",
+            "p4_port": "perforce:1666"
+        }
+    }
+
+    mocker.patch("perforce_triggers.config.get_config", return_value=config_)
+
+    with pytest.raises(exceptions.PerforceTriggersError) as error_:
+        perforce.connect_to_perforce()
+    assert "perforce login details are not configured correctly!" in str(error_)
+
+    # connection error
+    config_ = {
+        "auth": {
+            "p4_user": "jdoe",
+            "p4_port": "perforce:1666",
+            "p4_tickets": "/home/jdoe/.p4tickets"
+        }
+    }
+    mocker.patch("perforce_triggers.config.get_config", return_value=config_)
+
+    class P4Mock:
+        def connect():
+            raise P4Exception("failed")
+    mocker.patch("P4.P4", new=P4Mock())
+    
+    with pytest.raises(exceptions.PerforceTriggersError) as error_:
+        perforce.connect_to_perforce()
+    assert "Failed to connect to perforce server 'perforce:1666' as user 'jdoe'" in str(error_)

--- a/tests/test_triggers.py
+++ b/tests/test_triggers.py
@@ -179,7 +179,7 @@ def test_get_triggers(trigger_config, expected, raise_exception, mocker):
         })
     if raise_exception:
         with pytest.raises(exceptions.PerforceTriggersError):
-            triggers.get_triggers()
+            triggers.get_triggers_from_config()
     else:
-        res = triggers.get_triggers()
+        res = triggers.get_triggers_from_config()
         assert all(trigger_ in expected for trigger_ in res)


### PR DESCRIPTION
- Add `perforce` module
- Implement : 
   - `get_perforce_connection()`: connects to p4 server and return the connection object.
   - `get_triggers()`: returns a list of active `perforce` triggers.
- Rename the following functions:
   - `triggers.get_triggers()` -> `triggers.get_triggers_from_config()` to distinguish it from `perforce.get_triggers()` listing active triggers on `perforce`. 
